### PR TITLE
Release 1.6.4

### DIFF
--- a/index.php
+++ b/index.php
@@ -273,14 +273,14 @@ function updateAndSendMain(original, onSuccess) { //rather current HTML than ori
 
 	var storePosition = locateStoreArea(original);
 	var localPath = document.location.toString(); // url to display in the ~saving failed~ message
-	var newStore = updateOriginal(original, storePosition, localPath); // new html
-	if(!newStore)
+	var newHtml = updateOriginal(original, storePosition, localPath);
+	if(!newHtml)
 		return; // don`t notify: updateOriginal alerts already
 
 	var currentPageRequest = getCurrentTwRequestPart();
 	var urlEncodedRequestBody = 
-		"save=yes&content=" + encodeURIComponent(newStore)+
-		(currentPageRequest ? "&"+currentPageRequest : "")+
+		"save=yes&content=" + encodeURIComponent(newHtml) +
+		(currentPageRequest ? "&" + currentPageRequest : "") +
 		(config.options.chkSaveBackups ? ("&backupid=" + (new Date().convertToYYYYMMDDHHMMSSMMM())) : "");
 
 	// And save the new document using a HTML POST request

--- a/index.php
+++ b/index.php
@@ -232,18 +232,13 @@ convertUnicodeToFileFormat = function(s) { return config.browser.isIE ? convertU
 
 function asyncLoadOriginal(onSuccess) {
 
-	// Load the original and proceed on success
-	var xmlhttp = new XMLHttpRequest();
-	xmlhttp.onreadystatechange = function() {
-		if (this.readyState == 4) {
-			if(this.status == 200)
-				onSuccess(this.responseText);
-			else
-				displayMessage("Error while saving, failed to reach the server and load original, status: "+ this.status);
+	// GET call with no params loads the original
+	tiddlyBackend.call({
+		onSuccess: onSuccess,
+		onProblem: function(status) {
+			displayMessage("Error while saving, failed to reach the server and load original, status: "+ status);
 		}
-	}
-	xmlhttp.open("GET", getOriginalUrl() + document.location.search, true);
-	xmlhttp.send();
+	});
 };
 function getQueryParts() {
 

--- a/index.php
+++ b/index.php
@@ -485,6 +485,10 @@ function implementRequestProxying() {
 }
 
 window.tiddlyBackend = {
+	version: {
+		title: "MainTiddlyServer",
+		asString: "' . $version . '"
+	},
 	// auxiliary ("private") method
 	// params: { method?: "GET" | "POST" | ..., headers: { [name:string]: string }, body?: string (data form),
 	// onSuccess?: (responseText ??) => void, onProblem?: (status ??)=>void, isSync?: boolean }

--- a/index.php
+++ b/index.php
@@ -404,8 +404,8 @@ function setupGranulatedSaving() {
 
 function implementRequestProxying() {
 	window.config.orig_noProxy_httpReq = httpReq; //# or use window.httpReq?
-	httpReq = function(type, url, callback, params, headers, data, contentType, username, password, allowCache)
-	{
+	httpReq = function(type, url, callback, params, headers, data, contentType, username, password, allowCache) {
+
 		// in case of request to current MTS;
 		// we don`t try to guess if urls are the same when the ~index.php bit is omitted/added
 		// since we don`t know settings of the index file in the folder;

--- a/index.php
+++ b/index.php
@@ -1286,18 +1286,19 @@ else if (isset($_POST['options']))
 		else {
 			// set .htaccess and .htpasswd (apache 2.2.17 and below)
 			//# use apache_get_version() or $_SERVER['SERVER_SOFTWARE'] to tell that the password won't work when it is so
-			$htaccess = '<Files ~ "^\.(htaccess|htpasswd)$">
-Deny from all
-</Files>
-<FilesMatch "^(options\.txt|mts_options\.json)$">
-Deny from all
-</FilesMatch>
-ErrorDocument 401 "401 - Wrong Password"
-AuthName "Please enter your ID and password"
-AuthType Basic
-Require valid-user
-AuthGroupFile /dev/null
-AuthUserFile "' . getcwd() . '/.htpasswd"';
+			$htaccess = '
+			<Files ~ "^\.(htaccess|htpasswd)$">
+				Deny from all
+			</Files>
+			<FilesMatch "^(options\.txt|mts_options\.json)$">
+				Deny from all
+			</FilesMatch>
+			ErrorDocument 401 "401 - Wrong Password"
+			AuthName "Please enter your ID and password"
+			AuthType Basic
+			Require valid-user
+			AuthGroupFile /dev/null
+			AuthUserFile "' . getcwd() . '/.htpasswd"';
 			$htpasswd = $userName . ':' . crypt($passWord, base64_encode($passWord));
 
 			file_put_contents($serverFolder . "/" . ".htaccess", $htaccess);

--- a/index.php
+++ b/index.php
@@ -1237,7 +1237,7 @@ if (isset($_POST['save']) || isset($_POST['saveChanges']))
 
 	// first, backup if required
 	$backupId = preg_replace("/[^0-9\.]/", '', $_POST['backupid']);
-	if($backupId) copy($wikiPath, $wikiPath . ".$backupId.html");
+	if($backupId) copy($wikiPath, "$wikiPath.$backupId.html");
 
 	// then save
 	if(isset($_POST['save'])) {

--- a/index.php
+++ b/index.php
@@ -1043,7 +1043,7 @@ function updateTW($wikiPath, $changes) { // TW-format-gnostic
 
 	if($changes == new stdClass()) // no changes
 		return 'no changes, nothing to save';
-	
+
 	// a helper
 	function preg_offset($pattern, $text, $skip) {
 		preg_match($pattern, $text, $match, PREG_OFFSET_CAPTURE);
@@ -1059,7 +1059,7 @@ function updateTW($wikiPath, $changes) { // TW-format-gnostic
 		$memoryPeakUsageBeforeUpdate = memory_get_peak_usage();
 		file_put_contents('test_incremental_saving__was.txt', $wikiText);
 	}
-	
+
 	$LINEBREAK = '(?:\r?\n)';
 	// split html into parts before store, store itself and after store (using DOMDocument fails with TWc, see test_dom.php)
 	$re_store_area_div = '/<[dD][iI][vV] id=["\']?storeArea["\']?>'.$LINEBREAK.'?/'; //<div id="storeArea">\n
@@ -1075,7 +1075,7 @@ function updateTW($wikiPath, $changes) { // TW-format-gnostic
 	//^ second considerable load and peak rise in memory usage
 	unset($wikiText); // no longer needed, spare memory
 //# return error msg if $beforeStorePart or $afterStorePart is empty (~wrong format/not a TW, .. not found)
-	
+
 	// extract tiddlers into $tiddlersMap (divs inside #storeArea, see updateOriginal)
 	$re_stored_tiddler = '#<div [^>]+>\s*<pre>[^<]*?</pre>\s*</div>#';
 	preg_match_all($re_stored_tiddler, $storePart, $tiddlersArray); //# can we use explode instead?
@@ -1096,7 +1096,7 @@ function updateTW($wikiPath, $changes) { // TW-format-gnostic
 	if($debug_mode) {
 		file_put_contents('test_store_area_locating.txt', '$tiddlersMap length: '.count($tiddlersMap).":\n\n".print_r($tiddlersMap, true));
 	}
-	
+
 	// apply tiddler changes
 	if($debug_mode) {
 		file_put_contents('test_changes_parsing.txt', print_r($changes, true));
@@ -1148,7 +1148,7 @@ function updateTW($wikiPath, $changes) { // TW-format-gnostic
 // actually, we don't even need to concatenate these: we can use fwrite() and save those one-by one
 	if($debug_mode) {
 		file_put_contents('test_incremental_saving__became.txt', $wikiText);
-		
+
 		$memoryUsageAfterUpdate = memory_get_peak_usage();
 
 		file_put_contents('test_memory_usage.txt',
@@ -1158,7 +1158,7 @@ function updateTW($wikiPath, $changes) { // TW-format-gnostic
 			"\npeak in process: ".$memoryPeakUsageMiddleOfUpdate.
 			"\nafter: ".$memoryUsageAfterUpdate);
 	}
-	
+
 	// save changed wiki
 	$saved = lock_and_write_file($wikiPath, $wikiText);
 	if(!$saved)

--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php
 // MainTiddlyServer
-$version = '1.6.3';
+$version = '1.7.0';
 // MIT-licensed (see https://yakovl.github.io/MainTiddlyServer/license.html)
 $debug_mode = false;
 
@@ -116,7 +116,9 @@ You will then be asked to perform some initial configuration, after which you ca
 	
 	(forked from MTS v2.8.1.0, see https://groups.google.com/forum/#!topic/tiddlywiki/25LbvckJ3S8)
 	changes from the original version:
-	+ reduced the number of injected JS parts
+	1.7.0
+	+ reduced injected JS to just one chunk, simplified injecting/removing on backend,
+	  fixed removeInjectedJsFromWiki for upgrading TW: don't modify the file if injected bits are not found
 	+ added support of TWs with CRLF linebreaks (for instance, git changes them so)
 	+ made messages about unsupported TW versions more specific and helpful
 	+ improved paddings in the list of ?wikis for touch devices
@@ -124,6 +126,12 @@ You will then be asked to perform some initial configuration, after which you ca
 	+ fixed conflicts of simultaneous proxied requests from different working folders
 	+ added locking options/TW files when reading/writing to avoid conflicts
 	+ refactored options into a singleton class
+	+ update latest tested TW version to 2.9.3
+	+ fixed store dirtiness when changes to save are empty
+	+ introduced tiddlyBackend on front-end, encapsulated several methods into it from global scope,
+	  exposed MTS version in it for feature detection
+	+ implemented ?backupByName endpoint and decorated copyFile so that during TW upgrading the backup is really saved
+	. started using contemporary JS bits (arrow functions, const/let)
 	1.6.3
 	+ introduce single wiki mode
 	+ refactored various bits of code, setting memory_limit should now work consistently

--- a/index.php
+++ b/index.php
@@ -271,10 +271,11 @@ function updateAndSendMain(original, onSuccess) { //rather current HTML than ori
 	var documentStart = original.indexOf("<!DOCTYPE");
 	original = original.substring(documentStart);
 
-	var localPath = document.location.toString(); // url to display in the ~saving failed~ message
+	// url to display in the ~saving failed~ message
+	var localPath = document.location.toString();
+	// alerts on fail, so we don`t notify (again)
 	var newHtml = updateOriginal(original, null, localPath);
-	if(!newHtml)
-		return; // don`t notify: updateOriginal alerts already
+	if(!newHtml) return;
 
 	var currentPageRequest = getCurrentTwRequestPart();
 	var urlEncodedRequestBody = 

--- a/index.php
+++ b/index.php
@@ -435,8 +435,10 @@ function setupGranulatedSaving() {
 	window.saveOnlineGranulatedChanges = function() {
 	
 		var dataToSend = JSON.stringify(store.getChanges());
-		if(dataToSend == "{}")
+		if(dataToSend == "{}") {
+			store.setDirty(false);
 			return;
+		}
 		var currentPageRequest = getCurrentTwRequestPart();
 		var urlEncodedRequestBody = "saveChanges="+encodeURIComponent(dataToSend)+
 			(currentPageRequest ? "&"+currentPageRequest : "")+

--- a/index.php
+++ b/index.php
@@ -92,11 +92,6 @@ You will then be asked to perform some initial configuration, after which you ca
 	* test and add support of TW below 2.6.5 (build autotests)
 	* extend isTwLike to recognize PureStore
 	* test with IE: is encoding of non-latin letters broken? (change the convertUnicodeToFileFormat patch accordingly)
-	* reduce async implementation of asyncLoadOriginal, updateAndSendMain via httpReq
-	 . use httpReq("GET",url,callback,paramsToPassToCallback,null,data,contentType) (already written in comment)
-	  . set contentType to "application/x-www-form-urlencoded" or omit (this is the default value)
-	  ? when httpReq was introduced? (what TW versions we support?)
-	 . much code is shared with the new ~saving by patching~ – make it more DRY
 	password-protection to-dos:
 	- make password field type="password" and add a duplicate field to check if those values coincide
 	. until we stop relying on Apache:

--- a/index.php
+++ b/index.php
@@ -1215,7 +1215,7 @@ function getFullWikiLink($nameOrPath) {
 	return $link . 'wiki=' . str_replace('+', '%2B', $nameOrPath);
 }
 
-// If this is an AJAX request to save the file, do so, for incremental changes echo 'saved' on success and error on fail
+// If this is an AJAX request to save the file, do so, for incremental changes respond 'saved' on success and error on fail
 if (isset($_POST['save']) || isset($_POST['saveChanges']))
 {
 	$nameOfTwToUpdate = $_POST['wiki'] ? $_POST['wiki'] : Options::get('wikiname');
@@ -1242,7 +1242,7 @@ if (isset($_POST['save']) || isset($_POST['saveChanges']))
 	} else { // incremental saving from the saveChanges request
 		$changesJSON = $_POST['saveChanges'];
 		$changes = json_decode($changesJSON);
-		$errors = updateTW($wikiPath,$changes);
+		$errors = updateTW($wikiPath, $changes);
 		$successStatus = $errors ? $errors : 'saved';
 		echo $successStatus;
 	}

--- a/index.php
+++ b/index.php
@@ -628,15 +628,14 @@ function removeInjectedJsFromWiki($content) {
 	global $injectedJsHelpers;
 
 	// we imply that $injectedJsHelpers are either unchanged inside TW html or not present at all (may be so on upgrading)
+	// we also imply that they are only present in the code (and not inside TW content) == there's just 1 occurrence
+	//# try  return str_replace($injectedJsHelpers, '', $content);  instead (compare times, memory usage)
 	$start = strpos($content, $injectedJsHelpers);
 	if($start === false) {
 		return $content;
 	}
-	//# can we avoid implying that $injectedJsHelpers is not present inside TW content?
 	$end = $start + strlen($injectedJsHelpers);
-	$content = substr($content, 0, $start) . substr($content, $end); //# try str_replace/str_ireplace instead (compare times)
-
-	return $content;
+	return substr($content, 0, $start) . substr($content, $end);
 }
 function getTwVersion($wikiFileText) {
 

--- a/index.php
+++ b/index.php
@@ -506,7 +506,7 @@ function implementRequestProxying() {
 }
 
 window.tiddlyBackend = {
-	init() {
+	init: function() {
 		if(this.isInitialized) return;
 		this.isInitialized = true;
 

--- a/index.php
+++ b/index.php
@@ -1224,7 +1224,7 @@ if (isset($_POST['save']) || isset($_POST['saveChanges']))
 		echo "error: \"$nameOfTwToUpdate\" is not a valid TiddlyWiki in the working folder";
 		return;
 	}
-	$wikiPath = $workingFolder . $nameOfTwToUpdate;
+	$wikiPath = $workingFolder . "/" . $nameOfTwToUpdate;
 
 	// first, backup if required
 	$backupId = preg_replace("/[^0-9\.]/", '', $_POST['backupid']);

--- a/index.php
+++ b/index.php
@@ -411,26 +411,27 @@ function setupGranulatedSaving() {
 	}
 
 	window.saveOnlineGranulatedChanges = function() {
-	
+
 		var dataToSend = JSON.stringify(store.getChanges());
 		if(dataToSend == "{}") {
 			store.setDirty(false);
 			return;
 		}
-		var currentPageRequest = getCurrentTwRequestPart();
-		var urlEncodedRequestBody = "saveChanges="+encodeURIComponent(dataToSend)+
-			(currentPageRequest ? "&"+currentPageRequest : "")+
-			(config.options.chkSaveBackups ? ("&backupid=" + (new Date().convertToYYYYMMDDHHMMSSMMM())) : "");
-	
-		httpReq("POST", getOriginalUrl(), function(success, params, responseText, url, xhr) {
-			if(success) {
+
+		tiddlyBackend.call({
+			method: "POST",
+			onSuccess: function(responseText) {
 				if(responseText == "saved")
 					confirmMainSaved();
 				else
-					displayMessage("Error while saving. Server:\n"+responseText);
-			} else
-				displayMessage("Error while saving, failed to reach the server, status: "+xhr.status);
-		}, null/*params for callback*/, null, urlEncodedRequestBody);
+					displayMessage("Error while saving. Server:\n" + responseText);
+			},
+			onProblem: function(status) {
+				displayMessage("Error while saving, failed to reach the server, status: "+ status);
+			},
+			body: "saveChanges="+encodeURIComponent(dataToSend) +
+				(config.options.chkSaveBackups ? ("&backupid=" + (new Date().convertToYYYYMMDDHHMMSSMMM())) : "")
+		});
 	};
 
 	// when successfully saved, update .storedTiddlers etc

--- a/index.php
+++ b/index.php
@@ -634,7 +634,7 @@ function getTwVersion($wikiFileText) {
 	return $match;
 }
 define("EARLIEST_TESTED_VERSION", 20600);
-define("LATEST_TESTED_VERSION", 20902);
+define("LATEST_TESTED_VERSION", 20903);
 function isSupportedTwVersion($versionParts) {
 
 	if(!$versionParts)

--- a/index.php
+++ b/index.php
@@ -489,6 +489,23 @@ window.tiddlyBackend = {
 		title: "MainTiddlyServer",
 		asString: "' . $version . '"
 	},
+	init: function() {
+		if(this.isInitialized) return;
+		this.isInitialized = true;
+
+		config.options.chkHttpReadOnly = false;
+
+		implementRequestProxying();
+
+		if(isGranulatedSavingSupported())
+			setupGranulatedSaving();
+
+		// override saving
+		window.saveChanges = function(onlyIfDirty, tiddlers) {
+			if(onlyIfDirty && !store.isDirty()) return;
+			return saveOnlineChanges();
+		};
+	},
 	// auxiliary ("private") method
 	// params: { method?: "GET" | "POST" | ..., headers: { [name:string]: string }, body?: string (data form),
 	// onSuccess?: (responseText ??) => void, onProblem?: (status ??)=>void, isSync?: boolean }
@@ -518,23 +535,6 @@ window.tiddlyBackend = {
 		xhr.open(method, url, !params.isSync);
 		for(var name in headers) xhr.setRequestHeader(name, headers[name]);
 		xhr.send(body);
-	},
-	init: function() {
-		if(this.isInitialized) return;
-		this.isInitialized = true;
-
-		config.options.chkHttpReadOnly = false;
-
-		implementRequestProxying();
-
-		if(isGranulatedSavingSupported())
-			setupGranulatedSaving();
-
-		// override saving
-		window.saveChanges = function(onlyIfDirty, tiddlers) {
-			if(onlyIfDirty && !store.isDirty()) return;
-			return saveOnlineChanges();
-		};
 	}
 }
 

--- a/index.php
+++ b/index.php
@@ -271,9 +271,8 @@ function updateAndSendMain(original, onSuccess) { //rather current HTML than ori
 	var documentStart = original.indexOf("<!DOCTYPE");
 	original = original.substring(documentStart);
 
-	var storePosition = locateStoreArea(original);
 	var localPath = document.location.toString(); // url to display in the ~saving failed~ message
-	var newHtml = updateOriginal(original, storePosition, localPath);
+	var newHtml = updateOriginal(original, null, localPath);
 	if(!newHtml)
 		return; // don`t notify: updateOriginal alerts already
 

--- a/index.php
+++ b/index.php
@@ -619,7 +619,11 @@ function removeInjectedJsFromWiki($content) {
 	
 	global $injectedJsHelpers;
 
-	$start = strpos($content, $injectedJsHelpers); //# we imply $injectedJsHelpers is in TW ~html (and is not changed)
+	// we imply that $injectedJsHelpers are either unchanged inside TW html or not present at all (may be so on upgrading)
+	$start = strpos($content, $injectedJsHelpers);
+	if($start === false) {
+		return $content;
+	}
 	//# can we avoid implying that $injectedJsHelpers is not present inside TW content?
 	$end = $start + strlen($injectedJsHelpers);
 	$content = substr($content, 0, $start) . substr($content, $end); //# try str_replace/str_ireplace instead (compare times)

--- a/style.css
+++ b/style.css
@@ -1,7 +1,11 @@
 @import url('https://fonts.googleapis.com/css?family=Roboto+Slab:400,700');
 :root {
-	--primary-rgb: 221, 221, 221; /* todo: colorize */
-	--darkish: #777777; /* todo: colorize */
+	/* todo: try this approach instead for primary/opacity: https://stackoverflow.com/a/47831336/3995261 */
+	--primary-rgb: 246, 234, 196;
+	--darkish: #888577;
+	/* todo: try more colorizing, like:
+	   #8bd9f5 outside, #014353 for meta and main font color, #048cbd for links;
+	   check also TWC colors */
 	--meta-background: black;
 	font-family: 'Roboto Slab', sans-serif;
 	font-size: 16px; /* let's set explicitly */

--- a/style.css
+++ b/style.css
@@ -1,14 +1,14 @@
 @import url('https://fonts.googleapis.com/css?family=Roboto+Slab:400,700');
 :root {
-	--main-gray: #dddddd; /* #ffffdd */
-	--dark-gray: #777777; /* #4444cc */
+	--primary-rgb: 221, 221, 221; /* todo: colorize */
+	--darkish: #777777; /* todo: colorize */
 	--meta-background: black;
 	font-family: 'Roboto Slab', sans-serif;
 	font-size: 16px; /* let's set explicitly */
 }
 body {
 	margin: 0;
-	background-color: var(--dark-gray);
+	background-color: var(--darkish);
 }
 @media (min-width: 60em) {
 	body {
@@ -16,7 +16,7 @@ body {
 	}
 }
 .wrapper {
-	background-color: var(--main-gray);
+	background-color: rgb(var(--primary-rgb));
 
 	width: 40em;
 	max-width: 100%;
@@ -33,11 +33,13 @@ body {
 	padding-right: 1rem;
 	/* add some padding left and right, should be used on mobile */
 }
+.page-header, .navigation, .wrapper__footer {
+	background-color: var(--meta-background);
+	color: rgb(var(--primary-rgb));
+	text-align: center;
+}
 
 .page-header {
-	text-align: center;
-	background-color: var(--meta-background);
-	color: var(--main-gray);
 	padding-top: 1.5em;
 	padding-bottom: 1.5em;
 	margin-bottom: 0.1em;
@@ -54,22 +56,19 @@ body {
 
 .navigation {
 	padding: 0; margin: 0;
-	text-align: center;
-	background-color: var(--meta-background);
-	color: var(--main-gray);
 }
 .navigation__link {
 	display: inline-block; padding: 1em 2em;
 	text-decoration: none;
 	color: inherit;
 }
-.navigation__link:hover  { background-color: #151515; }
-.navigation__link:active { background-color: #202020; }
+.navigation__link:hover  { background-color: rgba(var(--primary-rgb), 0.3); }
+.navigation__link:active { background-color: rgba(var(--primary-rgb), 0.2); }
 .navigation__link_currently-opened {
 	font-weight: bold;
 	pointer-events: none;
 	cursor: default;
-	background-color: #202020;
+	background-color: rgba(var(--primary-rgb), 0.2);
 }
 
 main {
@@ -86,7 +85,7 @@ main p, main section>ul, main section>ol {
 	margin-top: 0.2em; margin-bottom: 0.2em;
 }
 main ul, main ol { padding-left: 1.6em; }
-main a { color: var(--dark-gray); }
+main a { color: var(--darkish); }
 
 .donation-form {
 	display: flex;
@@ -97,10 +96,6 @@ main a { color: var(--dark-gray); }
 }
 
 .wrapper__footer {
-	background-color: var(--meta-background);
-	color: var(--main-gray);
-	
-	text-align: center;
 	font-size: 0.8rem;
 	
 	margin-top: auto; /* https://stackoverflow.com/a/47640893/3995261 */


### PR DESCRIPTION
This release (in fact, will be 1.7.0) is intended for

* support TW 2.9.3
* flushing old changes
* applying refactoring to better future dev
  * exposed MTS version on frontend for easier feature detection
  * started to use contemporary JS bits as MTS is not supposed to work with really old browsers (unlike TWC itself)
* implementing `copyFile` overriding so that backuping, including during upgrading, works correctly, and upgrading of TW via MTS is possible

Todo

- [x] test & commit implemention of `copyFile` and its backend counterpart
- [x] update version and changelog
- [x] review site: any updates needed?
  - changed colors from gray-ish to warmer ones
  - content updates are needed, but they are not related to this release and hence are not blocking